### PR TITLE
Add Path Resolver Algorithms

### DIFF
--- a/.prettierrc.yml
+++ b/.prettierrc.yml
@@ -1,2 +1,3 @@
 trailingComma: "all"
 singleQuote: true
+printWidth: 120

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
   "editor.tabSize": 2,
-  "editor.rulers": [80, 120],
+  "editor.rulers": [120],
   "editor.formatOnSave": true,
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "prettier.configPath": ".prettierrc.yml",

--- a/src/fileDescriptor/fileDescriptor.test.ts
+++ b/src/fileDescriptor/fileDescriptor.test.ts
@@ -1,4 +1,4 @@
-import { FileDescriptor, FolderDescriptorImpl } from '.';
+import { type FileDescriptor, FileDescriptorImpl, FolderDescriptorImpl } from '.';
 
 describe('fileDescriptor', () => {
   describe('creating a file', () => {
@@ -6,7 +6,7 @@ describe('fileDescriptor', () => {
     let file: FileDescriptor;
     beforeEach(() => {
       folder = new FolderDescriptorImpl();
-      file = new FileDescriptor('file.txt', folder);
+      file = new FileDescriptorImpl('file.txt', folder);
     });
 
     it('should create a file', () => {

--- a/src/fileDescriptor/fileDescriptor.ts
+++ b/src/fileDescriptor/fileDescriptor.ts
@@ -1,9 +1,15 @@
 import { type FolderDescriptorImpl, type FileSystemDescriptor } from '.';
 
+export interface FileDescriptor extends FileSystemDescriptor {
+  content: string;
+}
+
 /**
  * A file system descriptor that contains the content of a file. This must be a leaf node as it cannot hold any children.
  */
-export class FileDescriptor implements FileSystemDescriptor {
+export class FileDescriptorImpl implements FileDescriptor {
+  isFolder = false;
+
   name: string;
   parent: FolderDescriptorImpl;
   content: string;

--- a/src/fileDescriptor/folderDescriptor.test.ts
+++ b/src/fileDescriptor/folderDescriptor.test.ts
@@ -14,8 +14,8 @@ describe('folderDescriptor', () => {
       it('should have an empty name', () => {
         expect(rootFolder.name).toBe('');
       });
-      it('should have a null parent', () => {
-        expect(rootFolder.parent).toBeNull();
+      it('should have a parent that points to null', () => {
+        expect(rootFolder.parent).toBe(null);
       });
       it('should have a path of /', () => {
         expect(rootFolder.path).toBe('/');

--- a/src/fileDescriptor/folderDescriptor.ts
+++ b/src/fileDescriptor/folderDescriptor.ts
@@ -11,15 +11,16 @@ export interface FolderDescriptor extends FileSystemDescriptor {
 }
 
 export class FolderDescriptorImpl implements FolderDescriptor {
+  isFolder = true;
   name: string;
-  parent: FileSystemDescriptor | null;
+  parent: FolderDescriptor | null;
   content: FileSystemDescriptor[];
 
   /**
    * @param name The name of the folder. Null is allowed for the root node.
    * @param parent The parent folder of this folder. Null is allowed for the root node.
    */
-  constructor(name?: string | null, parent?: FileSystemDescriptor | null) {
+  constructor(name?: string | null, parent?: FolderDescriptor | null) {
     this.name = name ?? '';
     this.parent = parent ?? null;
     this.content = [];
@@ -38,17 +39,12 @@ export class FolderDescriptorImpl implements FolderDescriptor {
       throw new Error('content is undefined');
     }
 
-    if (
-      DISALLOWED_CONTENT_NAMES.includes(content.name) ||
-      content.name.includes(PATH_SEPARATOR)
-    ) {
+    if (DISALLOWED_CONTENT_NAMES.includes(content.name) || content.name.includes(PATH_SEPARATOR)) {
       throw new Error(`Invalid name ${content.name}`);
     }
 
     if (this.findChild(content.name) !== null) {
-      throw new Error(
-        `A file or folder with the name ${content.name} already exists in ${this.path}`,
-      );
+      throw new Error(`A file or folder with the name ${content.name} already exists in ${this.path}`);
     }
 
     this.content.push(content);

--- a/src/fileDescriptor/index.ts
+++ b/src/fileDescriptor/index.ts
@@ -1,3 +1,5 @@
+import { type FolderDescriptor } from './folderDescriptor';
+
 export type FileSystemDescriptorContent = FileSystemDescriptor[] | string;
 
 export interface FileSystemDescriptor {
@@ -14,12 +16,17 @@ export interface FileSystemDescriptor {
   /**
    * The node above this node in the file system. Null is allowed for the root node.
    */
-  parent: FileSystemDescriptor | null;
+  parent: FolderDescriptor | null;
 
   /**
    * The content of the node, which differs based on the specific type of node.
    */
   content: FileSystemDescriptorContent;
+
+  /**
+   * Returns true if this node can have children.
+   */
+  readonly isFolder: boolean;
 }
 
 export * from './fileDescriptor';

--- a/src/filesystem/filesystem.ts
+++ b/src/filesystem/filesystem.ts
@@ -1,0 +1,32 @@
+import { type FolderDescriptor, FolderDescriptorImpl } from '../fileDescriptor';
+import { resolvePath } from './pathResolvers';
+
+export interface FileSystem {
+  cd: (path: string) => void;
+}
+
+export function startFileSystem(): FileSystem {
+  return new FileSystemImpl();
+}
+
+export class FileSystemImpl implements FileSystem {
+  rootFolder: FolderDescriptor;
+  workingFolder: FolderDescriptor;
+
+  constructor() {
+    this.rootFolder = new FolderDescriptorImpl();
+    this.workingFolder = this.rootFolder;
+  }
+
+  cd(path: string): void {
+    const newWorkingFolder = resolvePath(path, this.workingFolder, this.rootFolder);
+    if (!newWorkingFolder.isFolder) {
+      throw new Error(`Path ${path} is not a folder`);
+    }
+    this.workingFolder = newWorkingFolder as FolderDescriptor;
+  }
+
+  pwd(): string {
+    return this.workingFolder.path;
+  }
+}

--- a/src/filesystem/pathResolvers.test.ts
+++ b/src/filesystem/pathResolvers.test.ts
@@ -1,0 +1,108 @@
+import { FileDescriptorImpl, FolderDescriptorImpl } from '../fileDescriptor';
+import { resolvePath, resolvePathRecursive } from './pathResolvers';
+
+describe('pathResolvers', () => {
+  let rootFolder: FolderDescriptorImpl;
+  let subFolder: FolderDescriptorImpl;
+  let sub2Folder: FolderDescriptorImpl;
+  let file: FileDescriptorImpl;
+  let subFolderFile: FileDescriptorImpl;
+  let sub2FolderFile: FileDescriptorImpl;
+
+  beforeEach(() => {
+    rootFolder = new FolderDescriptorImpl();
+    subFolder = new FolderDescriptorImpl('subFolder', rootFolder);
+    sub2Folder = new FolderDescriptorImpl('sub2Folder', subFolder);
+    file = new FileDescriptorImpl('file', rootFolder);
+    subFolderFile = new FileDescriptorImpl('subFolderFile', subFolder);
+    sub2FolderFile = new FileDescriptorImpl('sub2FolderFile', sub2Folder);
+
+    rootFolder.addContent(file);
+    rootFolder.addContent(subFolder);
+    subFolder.addContent(subFolderFile);
+    subFolder.addContent(sub2Folder);
+    sub2Folder.addContent(sub2FolderFile);
+  });
+
+  describe('resolvePath', () => {
+    describe('relative paths', () => {
+      let workingFolder: FolderDescriptorImpl;
+      beforeEach(() => {
+        workingFolder = subFolder;
+      });
+
+      it('should resolve the workingFolder ""', () => {
+        expect(resolvePath('', workingFolder, rootFolder)).toBe(subFolder);
+      });
+
+      it('should resolve the workingFolder "."', () => {
+        expect(resolvePath('.', workingFolder, rootFolder)).toBe(subFolder);
+      });
+
+      it('should resolve the workingFolder "./"', () => {
+        expect(resolvePath('./', workingFolder, rootFolder)).toBe(subFolder);
+      });
+
+      it('should resolve the parent folder on ..', () => {
+        expect(resolvePath('..', workingFolder, rootFolder)).toBe(rootFolder);
+      });
+
+      it('should resolve subfolders', () => {
+        expect(resolvePath('sub2Folder', workingFolder, rootFolder)).toBe(sub2Folder);
+      });
+
+      it('should resolve a file', () => {
+        expect(resolvePath('./sub2Folder/sub2FolderFile', workingFolder, rootFolder)).toBe(sub2FolderFile);
+      });
+
+      it('should throw an error if the path is invalid', () => {
+        expect(() => resolvePath('invalid', workingFolder, rootFolder)).toThrow();
+      });
+
+      it('should throw an error if the path is invalid', () => {
+        expect(() => resolvePath('./subFile/invalid', workingFolder, rootFolder)).toThrow();
+      });
+    });
+
+    describe('absolute paths', () => {
+      it('should resolve the root folder', () => {
+        expect(resolvePath('/', subFolder, rootFolder)).toBe(rootFolder);
+      });
+
+      it('should resolve subfolders', () => {
+        expect(resolvePath('/subFolder', subFolder, rootFolder)).toBe(subFolder);
+      });
+    });
+  });
+
+  describe('resolvePathRecursive', () => {
+    it('should resolve the root folder on empty', () => {
+      expect(resolvePathRecursive([], rootFolder)).toBe(rootFolder);
+    });
+
+    it('should resolve the sub folder', () => {
+      expect(resolvePathRecursive(['subFolder'], rootFolder)).toBe(subFolder);
+    });
+
+    it('should resolve the files', () => {
+      expect(resolvePathRecursive(['file'], rootFolder)).toBe(file);
+      expect(resolvePathRecursive(['subFolder', 'subFolderFile'], rootFolder)).toBe(subFolderFile);
+    });
+
+    it('should resolve .. form the root folder to the root folder', () => {
+      expect(resolvePathRecursive(['..'], rootFolder)).toBe(rootFolder);
+    });
+
+    it('should resolve .. anywhere in the path', () => {
+      expect(resolvePathRecursive(['subFolder', '..'], rootFolder)).toBe(rootFolder);
+    });
+
+    it('should throw an error if the path is invalid', () => {
+      expect(() => resolvePathRecursive(['invalid'], rootFolder)).toThrow();
+    });
+
+    it('should throw and error if the path traverses through a file', () => {
+      expect(() => resolvePathRecursive(['file', 'subFolder'], rootFolder)).toThrow();
+    });
+  });
+});

--- a/src/filesystem/pathResolvers.ts
+++ b/src/filesystem/pathResolvers.ts
@@ -1,0 +1,68 @@
+import { PATH_SEPARATOR } from '../constants';
+import type { FileSystemDescriptor, FolderDescriptor } from '../fileDescriptor';
+
+/**
+ * Helper function to resolve a Descriptor from a path starting at the workingDirectory.
+ *
+ * @param path the path (either relative or absolute) to resolve.
+ * @param workingFolder the working directory to use if the path is relative.
+ * @returns the FileSystemDescriptor for the path.
+ * @throws Error if the path is invalid in any way.
+ */
+export function resolvePath(
+  path: string,
+  workingFolder: FolderDescriptor,
+  rootFolder: FolderDescriptor,
+): FileSystemDescriptor {
+  const pathParts = path.split(PATH_SEPARATOR);
+  let currentDescriptor: FolderDescriptor = workingFolder;
+  if (path.startsWith(PATH_SEPARATOR)) {
+    currentDescriptor = rootFolder;
+  }
+  return resolvePathRecursive(pathParts, currentDescriptor);
+}
+
+/**
+ * Helper function to resolve a Descriptor from a path, already split into subarts (generally using the ) starting at the current directory.
+ * @param pathParts
+ * @param currentDescriptor
+ * @returns
+ */
+export function resolvePathRecursive(
+  pathParts: string[],
+  currentDescriptor: FileSystemDescriptor,
+): FileSystemDescriptor {
+  const nextPart = pathParts.shift();
+  if (nextPart == null) {
+    // We've reached the end of the path, we can return the current descriptor
+    return currentDescriptor;
+  }
+
+  if (nextPart === '' || nextPart === '.') {
+    // Stay in the same directory and continue
+    return resolvePathRecursive(pathParts, currentDescriptor);
+  }
+
+  // We know we are not at the end of the path, so if the current descriptor is not a folder, we can't continue and
+  // the overal path is invalid.
+  if (!currentDescriptor.isFolder) {
+    throw new Error(`Path ${currentDescriptor.name} is not a folder`);
+  }
+
+  // We know we can treat the current descriptor as a folder
+  const currentFolder = currentDescriptor as FolderDescriptor;
+  if (nextPart === '..') {
+    if (currentFolder.parent === null) {
+      // The root path is the only path that does not have a parent, we treat that as if its parent is itself.
+      return resolvePathRecursive(pathParts, currentFolder);
+    }
+    return resolvePathRecursive(pathParts, currentFolder.parent);
+  } else {
+    const child = currentFolder.findChild(nextPart);
+    if (child === null) {
+      throw new Error(`Path ${nextPart} does not exist`);
+    } else {
+      return resolvePathRecursive(pathParts, child);
+    }
+  }
+}


### PR DESCRIPTION
Add Path Resolver helper functions that allow users to traverse the tree by `/` separated paths.