### PR TITLE
Implement Folder Builders for mkdir

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -17,6 +17,6 @@
   "typescript.tsdk": ".yarn/sdks/typescript/lib",
   "typescript.enablePromptUseWorkspaceTsdk": true,
   "eslint.nodePath": ".yarn/sdks",
-  "prettier.prettierPath": ".yarn/sdks/prettier/index.cjs",
-  "jest.jestCommandLine": "yarn test"
+  "prettier.prettierPath": ".yarn/sdks/prettier/index.cjs"
+  // "jest.jestCommandLine": "yarn test"
 }

--- a/src/filesystem/filesystem.ts
+++ b/src/filesystem/filesystem.ts
@@ -1,9 +1,13 @@
 import { type FolderDescriptor, FolderDescriptorImpl } from '../fileDescriptor';
+import { buildFolder } from './folderBuilders';
 import { resolvePath } from './pathResolvers';
 
 export interface FileSystem {
-  cd: (path: string) => string;
   pwd: () => string;
+  cd: (path: string) => string;
+  ls: (path?: string) => string;
+  rm: (path?: string | null) => void;
+  mkdir: (path: string, makeParents: boolean) => void;
 }
 
 export function startFileSystem(): FileSystem {
@@ -17,6 +21,10 @@ export class FileSystemImpl implements FileSystem {
   constructor() {
     this.rootFolder = new FolderDescriptorImpl();
     this.workingFolder = this.rootFolder;
+  }
+
+  pwd(): string {
+    return this.workingFolder.path;
   }
 
   cd(path: string): string {
@@ -40,6 +48,13 @@ export class FileSystemImpl implements FileSystem {
     return resolvedFolder.content.map((descriptor) => descriptor.name).join(', ');
   }
 
+  mkdir(path: string, makeParents?: boolean | null): void {
+    if (makeParents == null) {
+      makeParents = false;
+    }
+    buildFolder(path, makeParents, this.workingFolder, this.rootFolder);
+  }
+
   rm(path?: string | null): void {
     if (path == null) {
       path = '';
@@ -58,9 +73,5 @@ export class FileSystemImpl implements FileSystem {
     }
 
     targetParent.removeContent(targetName);
-  }
-
-  pwd(): string {
-    return this.workingFolder.path;
   }
 }

--- a/src/filesystem/folderBuilders.test.ts
+++ b/src/filesystem/folderBuilders.test.ts
@@ -1,0 +1,202 @@
+import { FolderDescriptorImpl, type FolderDescriptor, FileDescriptorImpl } from '../fileDescriptor';
+import { buildFolder } from './folderBuilders';
+
+describe('folderBuilders', () => {
+  describe('buildFolder', () => {
+    let rootFolder: FolderDescriptor;
+
+    beforeEach(() => {
+      rootFolder = new FolderDescriptorImpl();
+    });
+
+    describe('relative paths', () => {
+      it('should create a folder', () => {
+        buildFolder('folder', false, rootFolder, rootFolder);
+        const folder = rootFolder.findChild('folder') as FolderDescriptor;
+        expect(folder).toBeDefined();
+        expect(folder.name).toBe('folder');
+        expect(folder.parent).toBe(rootFolder);
+        expect(folder.path).toBe('/folder/');
+        expect(folder.content).toEqual([]);
+      });
+
+      it('should create a folder with parent', () => {
+        buildFolder('folder/subFolder', true, rootFolder, rootFolder);
+        const folder = rootFolder.findChild('folder') as FolderDescriptor;
+        expect(folder).toBeDefined();
+        expect(folder.name).toBe('folder');
+        expect(folder.parent).toBe(rootFolder);
+        expect(folder.path).toBe('/folder/');
+
+        const subFolder = folder.findChild('subFolder') as FolderDescriptor;
+        expect(subFolder).toBeDefined();
+        expect(subFolder.name).toBe('subFolder');
+        expect(subFolder.parent).toBe(folder);
+        expect(subFolder.path).toBe('/folder/subFolder/');
+      });
+
+      it('should handle "." in paths', () => {
+        buildFolder('folder/./subfolder', true, rootFolder, rootFolder);
+        const folder = rootFolder.findChild('folder') as FolderDescriptor;
+        expect(folder).toBeDefined();
+        expect(folder.name).toBe('folder');
+        expect(folder.parent).toBe(rootFolder);
+        expect(folder.path).toBe('/folder/');
+
+        const subFolder = folder.findChild('subfolder') as FolderDescriptor;
+        expect(subFolder).toBeDefined();
+        expect(subFolder.name).toBe('subfolder');
+        expect(subFolder.parent).toBe(folder);
+        expect(subFolder.path).toBe('/folder/subfolder/');
+      });
+
+      it('should handle "//" in paths', () => {
+        buildFolder('folder//subfolder', true, rootFolder, rootFolder);
+        const folder = rootFolder.findChild('folder') as FolderDescriptor;
+        expect(folder).toBeDefined();
+        expect(folder.name).toBe('folder');
+        expect(folder.parent).toBe(rootFolder);
+        expect(folder.path).toBe('/folder/');
+
+        const subFolder = folder.findChild('subfolder') as FolderDescriptor;
+        expect(subFolder).toBeDefined();
+        expect(subFolder.name).toBe('subfolder');
+        expect(subFolder.parent).toBe(folder);
+        expect(subFolder.path).toBe('/folder/subfolder/');
+      });
+
+      describe('some existing paths', () => {
+        let folder: FolderDescriptor;
+        beforeEach(() => {
+          folder = new FolderDescriptorImpl('folder', rootFolder);
+          rootFolder.addContent(folder);
+        });
+
+        it('should handle some existing paths', () => {
+          buildFolder('folder/subfolder1', true, rootFolder, rootFolder);
+
+          const subfolder = folder.findChild('subfolder1') as FolderDescriptor;
+          expect(subfolder).toBeDefined();
+          expect(subfolder.name).toBe('subfolder1');
+          expect(subfolder.parent).toBe(folder);
+          expect(subfolder.path).toBe('/folder/subfolder1/');
+        });
+
+        it('should append to the existing folder', () => {
+          buildFolder('folder/subfolder1', true, rootFolder, rootFolder);
+          expect(folder.content.length).toBe(1);
+
+          buildFolder('folder/subfolder2', true, rootFolder, rootFolder);
+          expect(folder.content.length).toBe(2);
+        });
+      });
+
+      describe('a different working folder', () => {
+        let folder: FolderDescriptor;
+        beforeEach(() => {
+          folder = new FolderDescriptorImpl('folder', rootFolder);
+          rootFolder.addContent(folder);
+        });
+
+        it('should handle some existing paths', () => {
+          buildFolder('subfolder1', true, folder, rootFolder);
+
+          const subfolder1 = folder.findChild('subfolder1') as FolderDescriptor;
+          expect(subfolder1).toBeDefined();
+          expect(subfolder1.name).toBe('subfolder1');
+          expect(subfolder1.parent).toBe(folder);
+          expect(subfolder1.path).toBe('/folder/subfolder1/');
+        });
+      });
+
+      it('should throw an error if all folders already exist', () => {
+        buildFolder('folder/subfolder', true, rootFolder, rootFolder);
+        expect(() => {
+          buildFolder('folder/subfolder', true, rootFolder, rootFolder);
+        }).toThrow();
+      });
+    });
+
+    describe('absolute paths', () => {
+      let rootFolder: FolderDescriptor;
+      let workingFolder: FolderDescriptor;
+
+      beforeEach(() => {
+        rootFolder = new FolderDescriptorImpl();
+        workingFolder = new FolderDescriptorImpl('workingFolder', rootFolder);
+        rootFolder.addContent(workingFolder);
+      });
+
+      it('should create a folder', () => {
+        buildFolder('/folder', false, workingFolder, rootFolder);
+        const folder = rootFolder.findChild('folder') as FolderDescriptor;
+        expect(folder).toBeDefined();
+        expect(folder.name).toBe('folder');
+        expect(folder.parent).toBe(rootFolder);
+        expect(folder.path).toBe('/folder/');
+        expect(folder.content).toEqual([]);
+      });
+
+      it('should create parent folders', () => {
+        buildFolder('/folder/subFolder', true, workingFolder, rootFolder);
+        const folder = rootFolder.findChild('folder') as FolderDescriptor;
+        expect(folder).toBeDefined();
+        expect(folder.name).toBe('folder');
+        expect(folder.parent).toBe(rootFolder);
+        expect(folder.path).toBe('/folder/');
+
+        const subFolder = folder.findChild('subFolder') as FolderDescriptor;
+        expect(subFolder).toBeDefined();
+        expect(subFolder.name).toBe('subFolder');
+        expect(subFolder.parent).toBe(folder);
+        expect(subFolder.path).toBe('/folder/subFolder/');
+      });
+    });
+
+    describe('invalid paths', () => {
+      let existingFolder: FolderDescriptor;
+      beforeEach(() => {
+        existingFolder = new FolderDescriptorImpl('existingFolder', rootFolder);
+        rootFolder.addContent(existingFolder);
+      });
+
+      it('should throw an error if the path contains ..', () => {
+        expect(() => {
+          buildFolder('folder/../subfolder', true, rootFolder, rootFolder);
+        }).toThrow();
+
+        expect(rootFolder.findChild('folder')).toBeNull();
+        expect(rootFolder.content.length).toBe(1); // existingFolder
+      });
+
+      it('should throw an error if all folders already exist', () => {
+        expect(() => {
+          buildFolder('existingFolder', true, rootFolder, rootFolder);
+        }).toThrow();
+
+        expect(rootFolder.findChild('folder')).toBeNull();
+        expect(rootFolder.content.length).toBe(1); // existingFolder
+      });
+
+      it('should throw an error if the parent folder does not exist and makeParents is false', () => {
+        expect(() => {
+          buildFolder('folder/subfolder', false, rootFolder, rootFolder);
+        }).toThrow();
+
+        expect(rootFolder.findChild('folder')).toBeNull();
+        expect(rootFolder.content.length).toBe(1); // existingFolder
+      });
+
+      it('should throw an error if the path traverses a file', () => {
+        const file = new FileDescriptorImpl('file', rootFolder);
+        rootFolder.addContent(file);
+        expect(() => {
+          buildFolder('file/subfolder', true, rootFolder, rootFolder);
+        }).toThrow();
+
+        expect(rootFolder.findChild('folder')).toBeNull();
+        expect(rootFolder.content.length).toBe(2); // existingFolder, file
+      });
+    });
+  });
+});

--- a/src/filesystem/folderBuilders.ts
+++ b/src/filesystem/folderBuilders.ts
@@ -1,0 +1,59 @@
+import { PATH_SEPARATOR } from '../constants';
+import { type FolderDescriptor, type FileSystemDescriptor, FolderDescriptorImpl } from '../fileDescriptor';
+
+export function buildFolder(
+  path: string,
+  makeParents: boolean,
+  workingFolder: FolderDescriptor,
+  rootFolder: FolderDescriptor,
+): void {
+  const pathParts = path.split('/');
+  const currentDescriptor = path.startsWith('/') ? rootFolder : workingFolder;
+  buildFolderRecusive(pathParts, makeParents, currentDescriptor);
+}
+
+export function buildFolderRecusive(
+  pathParts: string[],
+  makeParents: boolean,
+  currentDescriptor: FileSystemDescriptor,
+): void {
+  if (!currentDescriptor.isFolder) {
+    throw new Error(`Path ${currentDescriptor.path} is not a folder`);
+  }
+  const currentFolder = currentDescriptor as FolderDescriptor;
+
+  const nextPart = pathParts.shift();
+  if (nextPart == null) {
+    return;
+  }
+
+  if (nextPart === '' || nextPart === '.') {
+    buildFolderRecusive(pathParts, makeParents, currentDescriptor);
+    return;
+  }
+
+  if (nextPart === '..') {
+    throw new Error(`Cannot create ${nextPart}. Is not valid path`);
+  }
+
+  const nextDescriptor = currentFolder.findChild(nextPart);
+  if (nextDescriptor != null) {
+    if (pathParts.length === 0) {
+      throw new Error(`Cannot create ${nextPart}. It already exists`);
+    }
+
+    buildFolderRecusive(pathParts, makeParents, nextDescriptor as FolderDescriptor);
+    return;
+  }
+
+  if (pathParts.length !== 0 && !makeParents) {
+    throw new Error(`Cannot create ${pathParts.join(PATH_SEPARATOR)}. Its parent ${nextPart} does not exist`);
+  }
+
+  const newFolder = new FolderDescriptorImpl(nextPart, currentFolder);
+  buildFolderRecusive(pathParts, makeParents, newFolder);
+
+  // the folder is only added to the parent after validating that all its children can be resolved or created. If any
+  // step errors, the new folder is not added to the parent, and will be lost when the function returns.
+  currentFolder.addContent(newFolder);
+}

--- a/src/filesystem/pathResolvers.ts
+++ b/src/filesystem/pathResolvers.ts
@@ -6,6 +6,7 @@ import type { FileSystemDescriptor, FolderDescriptor } from '../fileDescriptor';
  *
  * @param path the path (either relative or absolute) to resolve.
  * @param workingFolder the working directory to use if the path is relative.
+ * @param rootFolder the root directory to use if the path is absolute.
  * @returns the FileSystemDescriptor for the path.
  * @throws Error if the path is invalid in any way.
  */

--- a/src/filesystem/pathResolvers.ts
+++ b/src/filesystem/pathResolvers.ts
@@ -15,10 +15,7 @@ export function resolvePath(
   rootFolder: FolderDescriptor,
 ): FileSystemDescriptor {
   const pathParts = path.split(PATH_SEPARATOR);
-  let currentDescriptor: FolderDescriptor = workingFolder;
-  if (path.startsWith(PATH_SEPARATOR)) {
-    currentDescriptor = rootFolder;
-  }
+  const currentDescriptor = path.startsWith('/') ? rootFolder : workingFolder;
   return resolvePathRecursive(pathParts, currentDescriptor);
 }
 
@@ -57,12 +54,12 @@ export function resolvePathRecursive(
       return resolvePathRecursive(pathParts, currentFolder);
     }
     return resolvePathRecursive(pathParts, currentFolder.parent);
+  }
+
+  const child = currentFolder.findChild(nextPart);
+  if (child === null) {
+    throw new Error(`Path ${nextPart} does not exist`);
   } else {
-    const child = currentFolder.findChild(nextPart);
-    if (child === null) {
-      throw new Error(`Path ${nextPart} does not exist`);
-    } else {
-      return resolvePathRecursive(pathParts, child);
-    }
+    return resolvePathRecursive(pathParts, child);
   }
 }


### PR DESCRIPTION
Create helper functions to build folders based on input paths. These work recursively to allow you to create a single or many folders in the tree.